### PR TITLE
Make it work with IE11

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "react-dom": "^16.8.6"
   },
   "dependencies": {
-    "use-ssr": "^1.0.19"
+    "use-ssr": "^1.0.22"
   },
   "devDependencies": {
     "@testing-library/react-hooks": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7057,10 +7057,10 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
-use-ssr@^1.0.19:
-  version "1.0.19"
-  resolved "https://registry.yarnpkg.com/use-ssr/-/use-ssr-1.0.19.tgz#8c03bec79069103b2813f77d17d2e5fafc02461b"
-  integrity sha512-Bkor42KtUZHTTuEot4Nma0Q9bccu+ZOGqukyNJI1A11uSymNag7VX3ub2Rzi2nLez4fUYUUROn0mEtil5KOsCg==
+use-ssr@^1.0.22:
+  version "1.0.22"
+  resolved "https://registry.yarnpkg.com/use-ssr/-/use-ssr-1.0.22.tgz#a43c2587b1907fabda61c6542b80542c619228fe"
+  integrity sha512-0kA0qfI4uw7PeRsz7X0XOdl2CdbgMBSFhj3n5JzMu8ZNlcZ2NrarhGjdmoxW1Q5d3WtNKbCNIjns/CKhpL7z8g==
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
I could not get `react-useportal` to work with IE11 out of the box.

Using the latest `use-ssr` version makes it work though.

In my `package.json` file I added this to make `react-useportal` work with IE11

```bash
  "resolutions": {
    "use-ssr": "^1.0.22"
  }
```