### PR TITLE
Feature: support adding a className

### DIFF
--- a/examples/index.js
+++ b/examples/index.js
@@ -10,7 +10,7 @@ const Exmaple1 = () => {
       <h3>Example 1</h3>
       <button onClick={openPortal}>Open Portal</button>
       {isOpen && (
-        <Portal>
+        <Portal className="my-portal">
           <div>
             Cool
             <button onClick={closePortal}>Close Portal</button>

--- a/usePortal.ts
+++ b/usePortal.ts
@@ -27,7 +27,6 @@ type UsePortalOptions = {
   onOpen?: CustomEventHandler
   onClose?: CustomEventHandler
   onPortalClick?: CustomEventHandler
-  className?: string
 } & CustomEventHandlers
 
 type UsePortalObjectReturn = {} // TODO
@@ -43,7 +42,6 @@ export default function usePortal({
   onOpen,
   onClose,
   onPortalClick,
-  className,
   ...eventHandlers
 }: UsePortalOptions = {}): any {
   const { isServer, isBrowser } = useSSR()
@@ -63,9 +61,6 @@ export default function usePortal({
   useEffect(() => {
     if (isBrowser && !portal.current) {
       portal.current = document.createElement('div')
-      if(className){
-        portal.current.className = className
-      }
     }
 
   }, [isBrowser, portal])
@@ -180,8 +175,13 @@ export default function usePortal({
     }
   }, [isServer, handleOutsideMouseClick, handleKeydown, elToMountTo, portal])
 
-  const Portal = useCallback(({ children }: { children: ReactNode }) => {
-    if (portal.current != null) return createPortal(children, portal.current)
+  const Portal = useCallback(({ children, className }: { children: ReactNode, className: string }) => {
+    if (portal.current != null) {
+      if(className && portal.current){
+        portal.current.className = className
+      }
+      return createPortal(children, portal.current)
+    }
     return null
   }, [portal])
 

--- a/usePortal.ts
+++ b/usePortal.ts
@@ -59,10 +59,7 @@ export default function usePortal({
   const portal = useRef(isBrowser ? document.createElement('div') : null) as HTMLElRef
 
   useEffect(() => {
-    if (isBrowser && !portal.current) {
-      portal.current = document.createElement('div')
-    }
-
+    if (isBrowser && !portal.current) portal.current = document.createElement('div')
   }, [isBrowser, portal])
 
   const elToMountTo = useMemo(() => {

--- a/usePortal.ts
+++ b/usePortal.ts
@@ -27,6 +27,7 @@ type UsePortalOptions = {
   onOpen?: CustomEventHandler
   onClose?: CustomEventHandler
   onPortalClick?: CustomEventHandler
+  className?: string
 } & CustomEventHandlers
 
 type UsePortalObjectReturn = {} // TODO
@@ -42,6 +43,7 @@ export default function usePortal({
   onOpen,
   onClose,
   onPortalClick,
+  className,
   ...eventHandlers
 }: UsePortalOptions = {}): any {
   const { isServer, isBrowser } = useSSR()
@@ -59,7 +61,13 @@ export default function usePortal({
   const portal = useRef(isBrowser ? document.createElement('div') : null) as HTMLElRef
 
   useEffect(() => {
-    if (isBrowser && !portal.current) portal.current = document.createElement('div')
+    if (isBrowser && !portal.current) {
+      portal.current = document.createElement('div')
+      if(className){
+        portal.current.className = className
+      }
+    }
+
   }, [isBrowser, portal])
 
   const elToMountTo = useMemo(() => {


### PR DESCRIPTION
Would you consider adding support for className?

e.g.

```jsx
<Portal className="my-portal">
  <div>My modal component</div>
</Portal>
```


Or if this API is not desired, then I could adjust the PR to be like this instead.

```jsx 
const { Portal } = usePortal({ className: 'my-portal' })

<Portal>
  <div>My modal component</div>
</Portal>
```
