### PR TITLE
update README, customizing modal example

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ By using `onOpen`, `onClose` or any other event handler, you can modify the `Por
 
 ```jsx
 const useModal = () => {
-  const { isOpen, togglePortal, closePortal, Portal } = usePortal({
+  const { isOpen, openPortal, togglePortal, closePortal, Portal } = usePortal({
     onOpen({ portal }) {
       portal.current.style.cssText = `
         /* add your css here for the Portal */
@@ -167,6 +167,7 @@ const useModal = () => {
 
   return {
     Modal: Portal,
+    openModal: openPortal,
     toggleModal: togglePortal,
     closeModal: closePortal,
     isOpen


### PR DESCRIPTION
Customizing modal example code snippet won't work out of the box because it misses openPortal property in the destructuring, I have added it.