### PR TITLE
export UsePortalOptions allowing extension

### DIFF
--- a/usePortal.ts
+++ b/usePortal.ts
@@ -19,7 +19,7 @@ type EventListenersRef = MutableRefObject<{
   [K in keyof DOMAttributes<K>]?: (event: SyntheticEvent<any, Event>) => void
 }>
 
-type UsePortalOptions = {
+export type UsePortalOptions = {
   closeOnOutsideClick?: boolean
   closeOnEsc?: boolean
   bindTo?: HTMLElement // attach the portal to this node in the DOM


### PR DESCRIPTION
I found that if I wanted to implement a useDropdown in Typescript by building on usePortal, I needed the props interface exported in order to build on it.  Please consider accepting, thanks.

For example:
```
import usePortal, { UsePortalOptions } from "./usePortal";

type DropdownOptions = UsePortalOptions & {
  width: number;
  height?: number;
};

const useDropdown = ({ width, height, onOpen, ...config }: DropdownOptions) => {
  ...
}
```