### PR TITLE
Fix sourcemap error on create-react-app 5

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "outDir": "dist",
     "declaration": true,
     "sourceMap": true,
+    "inlineSources": true,
     "jsx": "react",
     "esModuleInterop": true,
     "types": [


### PR DESCRIPTION
Create react app 5 uses "source-map-loader" in webpack which cannot find the source maps and produces a warning.

I added inlineSources in tsconfig.json to fix this problem as proposed in this package here https://github.com/typestack/class-transformer/pull/473

To reproduce:
* Create a create react app project
* Add usePortal and use it. You will see the warnings.