### PR TITLE
Support opening the portal programmatically.

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ const App = () => {
 ```
 
 ### Customizing the Portal directly
-By using `onOpen`, `onClose` or any other event handler, you can modify the `Portal` and return it. See [useDropdown](https://codesandbox.io/s/useportal-usedropdown-587fo) for a working example. It's important that you pass the `event` object to `openPortal` and `togglePortal` otherwise you will need to attach a `ref` to the clicked element.
+By using `onOpen`, `onClose` or any other event handler, you can modify the `Portal` and return it. See [useDropdown](https://codesandbox.io/s/useportal-usedropdown-587fo) for a working example. If opening the portal from a click event it's important that you pass the `event` object to `openPortal` and `togglePortal` otherwise you will need to attach a `ref` to the clicked element (if you want to be able to open the portal without passing an event you will need to set `programmaticallyOpen` to `true`).
 
 ```jsx
 const useModal = () => {
@@ -191,7 +191,7 @@ const App = () => {
 **Make sure you are passing the html synthetic event to the `openPortal` and `togglePortal` . i.e. `onClick={e => openPortal(e)}`**
 
 ### Usage with a `ref`
-If for some reason, you don't want to pass around the `event` to `openPortal` or `togglePortal`, you can use a `ref` like this.
+If for some reason, you don't want to pass around the `event` to `openPortal` or `togglePortal` and you're not using `programmaticallyOpen`, you can use a `ref` like this.
 ```jsx
 import usePortal from 'react-useportal'
 
@@ -230,6 +230,7 @@ Options
 | `onClose` | This is used to call something when the portal is closed and to modify the css of the portal directly |
 | `onPortalClick` | This is fired whenever clicking on the `Portal` |
 | html event handlers (i.e. `onClick`) | These can be used instead of `onOpen` to modify the css of the portal directly. [`onMouseEnter` and `onMouseLeave` example](https://codesandbox.io/s/useportal-usedropdown-dgesf) |
+| `programmaticallyOpen` | This option allows you to open or toggle the portal without passing in an event. Default is `false` |
 
 ### Option Usage
 
@@ -240,7 +241,7 @@ const {
   togglePortal,
   isOpen,
   Portal,
-  // if you don't pass an event to openPortal, closePortal, or togglePortal, you will need
+  // if you don't pass an event to openPortal, closePortal, or togglePortal and you're not using programmaticallyOpen, you will need
   // to put this on the element you want to interact with/click
   ref,
   // if for some reason you want to interact directly with the portal, you can with this ref

--- a/examples/index.js
+++ b/examples/index.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React , { useEffect, useState } from 'react'
 import { render } from 'react-dom'
 import usePortal from '../usePortal'
 
@@ -44,8 +44,8 @@ const Example2 = () => {
         <FirstPortal>
           I'm First.
           <button
-            onClick={() => {
-              openSecondPortal();
+            onClick={(e) => {
+              openSecondPortal(e);
               closeFirstPortal();
             }}
           >
@@ -60,6 +60,37 @@ const Example2 = () => {
       )}
     </>
   );
+}
+
+const Example3 = () => {
+  const { openPortal, closePortal, isOpen, Portal } = usePortal({
+    programmaticallyOpen: true,
+    onClose: () => setOpen(false)
+  })
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      openPortal()
+    } else {
+      closePortal()
+    }
+  }, [closePortal, open, openPortal, setOpen])
+
+  return (
+    <>
+      <h3>Example 3</h3>
+      <button onClick={() => setOpen(true)}>Programmatically Open Portal</button>
+      {isOpen && (
+        <Portal>
+          <div>
+            This portal was opened via a state change
+            <button onClick={() => setOpen(false)}>Programmatically Close Portal</button>
+          </div>
+        </Portal>
+      )}
+    </>
+  )
 }
 
 // this should attach via `bind` so whatever you "bind" it to, you can click
@@ -87,6 +118,7 @@ function App() {
     <>
       <Exmaple1 />
       <Example2 />
+      <Example3 />
     </>
   )
 }

--- a/usePortal.test.ts
+++ b/usePortal.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks'
+import { act, renderHook } from '@testing-library/react-hooks'
 import usePortal, { errorMessage1 } from './usePortal'
 
 describe('usePortal', () => {
@@ -15,5 +15,12 @@ describe('usePortal', () => {
     } catch(err) {
       expect(err.message).toBe(errorMessage1)
     }
+  })
+
+  it('does not error if programmatically opening the portal', () => {
+    const { result } = renderHook(() => usePortal({ programmaticallyOpen: true }))
+    act(() => {
+      expect(result.current.openPortal).not.toThrow()
+    });
   })
 })


### PR DESCRIPTION
## Changes:
This PR adds support for cases where the portal needs to be opened programmatically. This is done through a new `programmaticallyOpen` option so that there are still errors when the event is not passed from click events (this seemed like a good tradeoff, but it could also just not have that error but that seems a little less dev friendly).

## QA:
- Run `yarn dev`.
- Click the button in the third example.
- The portal should appear and there should be no errors.
- Click outside the portal and it should close.

## Fixes
Fixes: #36.