### PR TITLE
Update peer deps to React 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "lint:watch": "watch 'yarn lint'"
   },
   "peerDependencies": {
-    "react": "^16.8.6 || ^17.0.0",
-    "react-dom": "^16.8.6 || ^17.0.0"
+    "react": "^16.8.6 || ^17.0.0 || ^18.0.0",
+    "react-dom": "^16.8.6 || ^17.0.0 || ^18.0.0"
   },
   "dependencies": {
     "use-ssr": "^1.0.22"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "react-dom": "^16.8.6 || ^17.0.0 || ^18.0.0"
   },
   "dependencies": {
-    "use-ssr": "^1.0.22"
+    "use-ssr": "^1.0.25"
   },
   "devDependencies": {
     "@testing-library/react-hooks": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7057,10 +7057,10 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
-use-ssr@^1.0.22:
-  version "1.0.22"
-  resolved "https://registry.yarnpkg.com/use-ssr/-/use-ssr-1.0.22.tgz#a43c2587b1907fabda61c6542b80542c619228fe"
-  integrity sha512-0kA0qfI4uw7PeRsz7X0XOdl2CdbgMBSFhj3n5JzMu8ZNlcZ2NrarhGjdmoxW1Q5d3WtNKbCNIjns/CKhpL7z8g==
+use-ssr@^1.0.25:
+  version "1.0.25"
+  resolved "https://registry.yarnpkg.com/use-ssr/-/use-ssr-1.0.25.tgz#c7f54b59d6e52db26749b1d4115a650101a190bd"
+  integrity sha512-VYF8kJKI+X7+U4XgGoUER2BUl0vIr+8OhlIhyldgSGE0KHMoDRXPvWeHUUeUktq7ACEOVLzXGq1+QRxcvtwvyQ==
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
This updates the `peerDependencies` to include React 18.

Fixes: #81.